### PR TITLE
Add Python tools

### DIFF
--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,2 +1,7 @@
 ## direnv: machine-specific settings
 # https://direnv.net/
+
+## Python
+
+#export PIP=pip3
+#export PYTHON=python3

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,5 @@
+tap "homebrew/bundle"
+brew "checkmake"
+brew "coreutils"
+brew "direnv"
+brew "pre-commit"

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,10 @@ _debug-prefix:
 install-assets: $(SUBDIRS)
 
 .PHONY: install-tools
-install-tools: pre-commit-install $(SUBDIRS)
+install-tools: install-homebrew pre-commit-install $(SUBDIRS)
+
+BREW ?= brew
+
+.PHONY: install-homebrew
+install-homebrew: #> Install packages with Homebrew
+	$(BREW) bundle install

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ debug-project:
 
 include make.d/direnv.mk make.d/help.mk make.d/pre-commit.mk
 
+include make.d/apt.mk
+include make.d/homebrew.mk
+
 #. STANDARD TARGETS
 
 .PHONY: all
@@ -65,10 +68,4 @@ _debug-prefix:
 install-assets: $(SUBDIRS)
 
 .PHONY: install-tools
-install-tools: install-homebrew pre-commit-install $(SUBDIRS)
-
-BREW ?= brew
-
-.PHONY: install-homebrew
-install-homebrew: #> Install packages with Homebrew
-	$(BREW) bundle install
+install-tools: homebrew-bundle-install pre-commit-install $(SUBDIRS)

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ debug-project:
 	$(info - SUBDIRS: $(SUBDIRS))
 	@:
 
-include make.d/direnv.mk make.d/help.mk make.d/pre-commit.mk
-
-include make.d/apt.mk
+include make.d/direnv.mk
+include make.d/help.mk
 include make.d/homebrew.mk
+include make.d/pre-commit.mk
 
 #. STANDARD TARGETS
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -17,12 +17,15 @@ ignoreWords: []
 import: []
 version: "0.2"
 words:
+  - autoupdate
   - Brode
   - checkmake
   - Codesandbox
+  - coreutils
   - datadirpkg
   - direnv
   - envrc
+  - fswatch
   - Haines
   - INSTALLFLAGS
   - kata
@@ -38,5 +41,6 @@ words:
   - Pipenv
   - Pipfile
   - pyenv
+  - shellcheck
   - sode
   - virtualenv

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -125,6 +125,7 @@ gaps between pip, python (using system python, pyenv or asdf) and virtualenv._
 _Python is a programming language that lets you work quickly and integrate systems more effectively_
 
 - Related:
+  - Override the path to the Python executable you want with [`direnv`](#direnv)
   - Automate installation with [Pipenv](#pipenv).
   - Automate installation with [pyenv](#pyenv).
 

--- a/make.d/homebrew.mk
+++ b/make.d/homebrew.mk
@@ -1,0 +1,10 @@
+ifneq (, $(shell which brew))
+$(info Homebrew detected)
+#. HOMEBREW TARGETS
+
+BREW ?= brew
+
+.PHONY: homebrew-bundle-install
+homebrew-bundle-install: #> Install packages from `Brewfile` with Homebrew
+	$(BREW) bundle install
+endif

--- a/make.d/homebrew.mk
+++ b/make.d/homebrew.mk
@@ -1,10 +1,8 @@
-ifneq (, $(shell which brew))
-$(info Homebrew detected)
 #. HOMEBREW TARGETS
 
 BREW ?= brew
 
 .PHONY: homebrew-bundle-install
 homebrew-bundle-install: #> Install packages from `Brewfile` with Homebrew
+	@type $(BREW) &> /dev/null || exit 0
 	$(BREW) bundle install
-endif

--- a/src/sode/Makefile
+++ b/src/sode/Makefile
@@ -3,7 +3,8 @@
 .PHONY: default
 default: all
 
-include ../../make.d/help.mk ../../make.d/pre-commit.mk
+include ../../make.d/help.mk
+include ../../make.d/pre-commit.mk
 
 ## Sources
 

--- a/src/sode/cspell.config.yaml
+++ b/src/sode/cspell.config.yaml
@@ -12,21 +12,8 @@ ignorePaths:
   - cspell.config.yaml
 ignoreWords: []
 import:
-  - ../cspell.config.yaml
+  - ../../cspell.config.yaml
 version: "0.2"
 words:
   - bambam
-  - bitovi
-  - Brode
   - BRODESODE
-  - datadirpkg
-  - frontends
-  - fscmd
-  - FSWATCH
-  - Groff
-  - INSTALLFLAGS
-  - libexecdirpkg
-  - MANDOC
-  - Pandoc
-  - PANDOCFLAGS
-  - sode

--- a/src/sode/manual/Brewfile
+++ b/src/sode/manual/Brewfile
@@ -1,0 +1,3 @@
+tap "homebrew/bundle"
+brew "fswatch"
+brew "pandoc"

--- a/src/sode/manual/Makefile
+++ b/src/sode/manual/Makefile
@@ -55,7 +55,7 @@ debug-paths:
 
 FSWATCH ?= fswatch
 
-INSTALL := install
+INSTALL ?= install
 INSTALLFLAGS := -g 0 -o 0
 
 MANDOC ?= mandoc

--- a/src/sode/manual/Makefile
+++ b/src/sode/manual/Makefile
@@ -6,7 +6,9 @@
 .PHONY: default
 default: all
 
-include ../../../make.d/help.mk ../../../make.d/paths-system.mk
+include ../../../make.d/help.mk
+include ../../../make.d/homebrew.mk
+include ../../../make.d/paths-system.mk
 
 ### Sources
 
@@ -139,5 +141,4 @@ install-assets:
 	@:
 
 .PHONY: install-tools
-install-tools:
-	@:
+install-tools: homebrew-bundle-install

--- a/src/sode/python/.editorconfig
+++ b/src/sode/python/.editorconfig
@@ -1,0 +1,9 @@
+root = false
+
+# Python
+
+[*.py]
+indent_size = 2
+indent_style = space
+max_line_length = 100
+trim_trailing_whitespace = true

--- a/src/sode/python/.envrc
+++ b/src/sode/python/.envrc
@@ -1,0 +1,6 @@
+# https://github.com/direnv/direnv/blob/master/man/direnv-stdlib.1.md#source_up-filename
+source_up .envrc
+
+# Activate virtualenv, for use of project-specific python and libraries
+# https://github.com/direnv/direnv/blob/master/man/direnv-stdlib.1.md#layout-pipenv
+layout pipenv

--- a/src/sode/python/Brewfile
+++ b/src/sode/python/Brewfile
@@ -1,0 +1,1 @@
+tap "homebrew/bundle"

--- a/src/sode/python/Brewfile
+++ b/src/sode/python/Brewfile
@@ -1,1 +1,3 @@
 tap "homebrew/bundle"
+brew "pyenv"
+brew "pipenv"

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -46,14 +46,19 @@ debug-paths:
 
 ## Programs
 
-INSTALL := install
+INSTALL ?= install
 INSTALLFLAGS := -g 0 -o 0
+
+PIP ?= pip
+PYTHON ?= python
 
 .PHONY: debug-programs
 debug-programs:
 	$(info Programs:)
 	$(info - INSTALL: $(INSTALL))
 	$(info - INSTALLFLAGS: $(INSTALLFLAGS))
+	$(info - PIP: $(PIP))
+	$(info - PYTHON: $(PYTHON))
 	@:
 
 #. STANDARD TARGETS

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -3,7 +3,9 @@
 .PHONY: default
 default: all
 
-include ../../../make.d/help.mk ../../../make.d/paths-system.mk
+include ../../../make.d/help.mk
+include ../../../make.d/homebrew.mk
+include ../../../make.d/paths-system.mk
 
 ## Sources
 
@@ -148,5 +150,8 @@ install-assets:
 	@:
 
 .PHONY: install-tools
-install-tools:
-	@:
+install-tools: homebrew-bundle-install
+
+.PHONY: install-pipenv
+install-pipenv:
+	$(PIP) install pipenv --user

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -52,6 +52,7 @@ INSTALL ?= install
 INSTALLFLAGS := -g 0 -o 0
 
 PIP ?= pip
+PIPENV ?= pipenv
 PYTHON ?= python
 
 .PHONY: debug-programs
@@ -60,8 +61,15 @@ debug-programs:
 	$(info - INSTALL: $(INSTALL))
 	$(info - INSTALLFLAGS: $(INSTALLFLAGS))
 	$(info - PIP: $(PIP))
+	$(info - PIPENV: $(PIPENV))
 	$(info - PYTHON: $(PYTHON))
 	@:
+
+#. PYTHON TARGETS
+
+.PHONY: run-main
+run-main: #> Run the main script with pipenv
+	$(PIPENV) run main
 
 #. STANDARD TARGETS
 

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -151,7 +151,3 @@ install-assets:
 
 .PHONY: install-tools
 install-tools: homebrew-bundle-install
-
-.PHONY: install-pipenv
-install-pipenv:
-	$(PIP) install pipenv --user

--- a/src/sode/python/Pipfile
+++ b/src/sode/python/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.13"

--- a/src/sode/python/Pipfile
+++ b/src/sode/python/Pipfile
@@ -9,3 +9,6 @@ name = "pypi"
 
 [requires]
 python_version = "3.13"
+
+[scripts]
+main = 'python sode.py'

--- a/src/sode/python/Pipfile.lock
+++ b/src/sode/python/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "494d5b4f482f0ef471f49afe28f00ec1a2ff75da2ce65060d8cabaeb3da2f100"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.13"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/src/sode/python/README.md
+++ b/src/sode/python/README.md
@@ -16,4 +16,5 @@ yet.
 
 ## pipenv
 
-Remember to use `pipenv shell` to set up the python interpreter.
+Remember to use `pipenv shell` to set up the python interpreter.  This appears to happen
+automatically with the use of a local `.envrc`.

--- a/src/sode/python/README.md
+++ b/src/sode/python/README.md
@@ -13,3 +13,7 @@ can use to invoke other commands that do various things I'm experimenting with. 
 be sufficiently useful may later graduate to–or re-spawn–in other repositories.  So this is an
 incubator for stuff I think may be worth automating, but that doesn't merit its own repository just
 yet.
+
+## pipenv
+
+Remember to use `pipenv shell` to set up the python interpreter.

--- a/src/sode/python/cspell.config.yaml
+++ b/src/sode/python/cspell.config.yaml
@@ -15,17 +15,4 @@ import:
   - ../cspell.config.yaml
 version: "0.2"
 words:
-  - bambam
-  - bitovi
-  - Brode
-  - BRODESODE
-  - datadirpkg
-  - frontends
-  - fscmd
-  - FSWATCH
-  - Groff
-  - INSTALLFLAGS
-  - libexecdirpkg
-  - MANDOC
-  - Pandoc
-  - PANDOCFLAGS
+  - pypi

--- a/src/sode/python/sode.py
+++ b/src/sode/python/sode.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 
 if __name__ == "__main__":
-    print("Hello world!")
+  print("Hello world!")


### PR DESCRIPTION
# Add Python tools

Add targets to `Makefiles` to install tools and interface with Python via
`pipenv`.  Also add `Brewfile` to automate `install-tools`, when on a platform
that has Homebrew installed (or else it will do nothing).`
