### PR TITLE
Try src-layout

### DIFF
--- a/.github/workflows/setuptools-src.yml
+++ b/.github/workflows/setuptools-src.yml
@@ -1,0 +1,87 @@
+name: setuptools-src
+description: Check setuptools-src
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/setuptools-src.yml'
+      - 'src/python/setuptools-src/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/setuptools-src.yml'
+      - 'src/python/setuptools-src/**'
+  workflow_dispatch:
+
+env:
+  python_cache: 'pipenv'
+  python_version: '3.13.2'
+  working_directory: ./src/python/setuptools-src
+
+permissions:
+  contents: read
+
+jobs:
+  setuptools-src:
+    defaults:
+      run:
+        working-directory: ${{ env.working_directory }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          cache: ${{ env.python_cache }}
+          cache-dependency-path: ${{ env.working_directory }}/Pipfile.lock
+          python-version: ${{ env.python_version }}
+
+      - run: python --version
+      - run: pip --version
+      - run: pipx --version
+
+      - run: pip install pipenv
+      - run: pipenv --version
+      - run: pipenv install --dev
+
+  setuptools-src-build:
+    defaults:
+      run:
+        working-directory: ${{ env.working_directory }}
+    needs: setuptools-src
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          cache: ${{ env.python_cache }}
+          cache-dependency-path: ${{ env.working_directory }}/Pipfile.lock
+          python-version: ${{ env.python_version }}
+
+      # Packages were already loaded from cache, but commands like pipenv et al won't be on the path
+      - run: pip install pipenv
+      - run: pipenv install --dev
+      - run: make
+
+  setuptools-src-install:
+    defaults:
+      run:
+        working-directory: ${{ env.working_directory }}
+    needs: setuptools-src-build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          cache: ${{ env.python_cache }}
+          cache-dependency-path: ${{ env.working_directory }}/Pipfile.lock
+          python-version: ${{ env.python_version }}
+
+      # Packages were already loaded from cache, but commands like pipenv et al won't be on the path
+      - run: pip install pipenv
+      - run: pipenv install --dev
+      - run: make install
+      - run: marvin

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ debug-programs:
 ## Project
 
 # https://stackoverflow.com/a/17845120/112682
-SUBDIRS := src/sode
+SUBDIRS := \
+	src/python/setuptools-flat \
+	src/python/setuptools-src \
+	src/sode
 
 .PHONY: $(SUBDIRS)
 $(SUBDIRS):

--- a/src/python/cspell.config.yaml
+++ b/src/python/cspell.config.yaml
@@ -34,6 +34,7 @@ words:
   - sdist
   - Setuptools
   - setuptoolsflat
+  - setuptoolssrc
   - subpkg
   - venv
   - virtualenv

--- a/src/python/setuptools-src/.gitignore
+++ b/src/python/setuptools-src/.gitignore
@@ -1,0 +1,13 @@
+## Make
+
+# File build times for phony targets, when artifact names aren't known in advance
+.sdist-timestamp
+.wheel-timestamp
+
+## Python
+
+# build
+*.egg-info/
+**/__pycache__/
+build/
+dist/

--- a/src/python/setuptools-src/Brewfile
+++ b/src/python/setuptools-src/Brewfile
@@ -1,0 +1,2 @@
+tap "homebrew/bundle"
+brew "pipx"

--- a/src/python/setuptools-src/Makefile
+++ b/src/python/setuptools-src/Makefile
@@ -200,7 +200,7 @@ clean-wheel:
 
 .PHONY: install-editable-wheel
 install-editable-wheel: wheel #> Link to the wheel globally with pipx
-	$(PIPX) install --editable .
+	$(PIPX) install --editable --force .
 
 .PHONY: install-wheel
 install-wheel: wheel #> Install the wheel globally with pipx

--- a/src/python/setuptools-src/Makefile
+++ b/src/python/setuptools-src/Makefile
@@ -154,18 +154,13 @@ pipenv-install: #> Install development dependencies with pipenv
 	$(PIPENV) install --dev
 
 .PHONY: run-cli
-run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible ways
+run-cli: run-cli-python run-cli-wheel #> Run the CLI all possible ways
 	@:
-
-.PHONY: run-cli-pipenv
-run-cli-pipenv: #> Run the program from a pipenv script
-	@echo ""
-	$(PIPENV) run cli
 
 .PHONY: run-cli-python
 run-cli-python: #> Run the program from venv-managed python
 	@echo ""
-	PYTHONPATH=. $(PIPENV) run python ./src/setuptoolssrc/cli.py
+	PYTHONPATH=src $(PIPENV) run python ./src/setuptoolssrc/cli.py
 
 #. PYTHON SOURCE DISTRIBUTION TARGETS
 

--- a/src/python/setuptools-src/Makefile
+++ b/src/python/setuptools-src/Makefile
@@ -1,0 +1,235 @@
+# setuptools: src structure
+
+.PHONY: default
+default: all
+
+# Local conventions:
+# - Distinguish standard and conventional targets from project-specific ones.
+# - Add conventional targets to discover targets and troubleshoot recipes without opening Makefiles.
+# - Group non-standard targets by artifact or tool type, starting with the artifact or tool name.
+# - Create variables in CAPS with defaults that can be overridden at runtime, for external programs.
+# - Create variables in snake_case that are not meant to be overridden at runtime.
+# - Put data and variables along with the targets that use them, when possible.
+# - Delegate targets to artifact- or tool-specific dependencies that start with the name of the
+#   top-level target (e.g. `install` depends upon `install-bin` and `install-lib`).
+
+# Project
+
+package_id := setuptoolssrc
+
+.PHONY: debug-project
+debug-project:
+	$(info Project)
+	$(info - package_id=$(package_id))
+	@:
+
+# Programs
+
+TAR ?= tar
+UNZIP ?= unzip
+
+.PHONY: debug-programs
+debug-programs:
+	$(info Programs)
+	$(info - TAR=$(TAR))
+	$(info - UNZIP=$(UNZIP))
+	@:
+
+# Sources
+
+sources_py := $(shell find src/setuptoolssrc -iname '*.py' | sort)
+sources := Pipfile Pipfile.lock pyproject.toml $(sources_py)
+
+.PHONY: debug-sources
+debug-sources:
+	$(info Sources)
+	$(info - sources=$(sources))
+	$(info - sources_py=$(sources_py))
+	@:
+
+# Artifacts
+
+.PHONY: debug-artifacts
+debug-artifacts:
+	$(info Artifacts:)
+	$(info - artifact_sdist=$(artifact_sdist))
+	$(info - artifact_wheel=$(artifact_wheel))
+	@:
+
+#. DEVELOPMENT ENVIRONMENT TARGETS
+
+BREW ?= brew
+
+.PHONY: debug-tools
+debug-tools:
+	$(info Development Environment)
+	$(info - BREW=$(BREW))
+	@:
+
+.PHONY: install-tools
+install-tools: homebrew-install #> Install development tools
+	@:
+
+.PHONY: homebrew-install
+homebrew-install:
+	$(BREW) bundle install
+
+#. STANDARD TARGETS
+
+.PHONY: all
+all: sdist wheel #> Build all artifacts
+	@:
+
+.PHONY: clean
+clean: clean-build clean-python clean-sdist clean-wheel pipenv-clean #> Remove files built from these sources
+	@:
+
+.PHONY: install
+install: install-wheel #> Install artifacts
+	@:
+
+.PHONY: uninstall
+uninstall: uninstall-wheel #> Uninstall artifacts
+	@:
+
+.PHONY: test
+test:
+	@:
+
+#. SUPPORT TARGETS
+
+.PHONY: check
+check: check-wheel #> Check if artifacts were installed correctly
+	@:
+
+.PHONY: debug
+debug: _debug-prefix debug-artifacts debug-programs debug-project debug-python debug-sources debug-tools #> Show debugging information
+	@:
+
+.PHONY: _debug-prefix
+_debug-prefix:
+	$(info ==setuptools: src structure==)
+	@:
+
+# Generate help documentation from Makefiles
+# hash-dot NAME => Section titled NAME
+# TARGET: hash-greater DESCRIPTION => Target description
+# https://stackoverflow.com/a/47107132/112682
+.PHONY: help
+help: #> Show this help
+	@sed -n \
+		-e '/@sed/!s/#[.] */_margin_\n/p' \
+		-e '/@sed/!s/:.*#> /:/p' \
+		$(MAKEFILE_LIST) \
+	| column -ts : | sed -e 's/_margin_//'
+
+#. PYTHON TARGETS
+
+BUILD ?= $(PIPENV) run python -m build
+PIPENV ?= pipenv
+PIPX ?= pipx
+
+.PHONY: clean-build
+clean-build: #> Remove files from running build
+	$(RM) -r build dist $(package_id).egg-info
+
+.PHONY: clean-python
+clean-python: #> Remove files from running python
+	$(RM) -r **/__pycache__
+
+.PHONY: debug-python
+debug-python:
+	$(info Programs)
+	$(info - BUILD=$(BUILD))
+	$(info - PIPENV=$(PIPENV))
+	$(info - PIPX=$(PIPX))
+	@:
+
+.PHONY: pipenv-clean
+pipenv-clean: #> Uninstall unused packages from virtualenv
+	$(PIPENV) clean
+
+.PHONY: pipenv-install
+pipenv-install: #> Install development dependencies with pipenv
+	$(PIPENV) install --dev
+
+.PHONY: run-cli
+run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible ways
+	@:
+
+.PHONY: run-cli-pipenv
+run-cli-pipenv: #> Run the program from a pipenv script
+	@echo ""
+	$(PIPENV) run cli
+
+.PHONY: run-cli-python
+run-cli-python: #> Run the program from venv-managed python
+	@echo ""
+	PYTHONPATH=. $(PIPENV) run python ./src/setuptoolssrc/cli.py
+
+#. PYTHON SOURCE DISTRIBUTION TARGETS
+
+artifact_sdist = $(wildcard dist/$(package_id)*.tar.gz)
+sdist_timestamp := .sdist-timestamp
+
+.PHONY: clean-sdist
+clean-sdist:
+	$(RM) $(sdist_timestamp)
+
+.PHONY: sdist
+sdist: $(sdist_timestamp) #> Build the source distribution
+	@:
+
+.PHONY: sdist-contents
+sdist-contents: sdist #> Show what's inside the sdist
+	$(TAR) tfz $(artifact_sdist)
+
+# Phony target timestamp, to avoid guessing target name of artifact named with source code version
+$(sdist_timestamp): $(sources)
+	$(BUILD) --sdist
+	@touch $@
+
+#. PYTHON WHEEL TARGETS
+
+artifact_wheel = $(wildcard dist/$(package_id)*.whl)
+cmd_name := marvin
+wheel_timestamp := .wheel-timestamp
+
+.PHONY: check-wheel
+check-wheel:
+	@type $(cmd_name) &> /dev/null || ( echo "$(cmd_name): not found"; exit 1 )
+
+.PHONY: clean-wheel
+clean-wheel:
+	$(RM) $(wheel_timestamp)
+
+.PHONY: install-editable-wheel
+install-editable-wheel: wheel #> Link to the wheel globally with pipx
+	$(PIPX) install --editable .
+
+.PHONY: install-wheel
+install-wheel: wheel #> Install the wheel globally with pipx
+	$(PIPX) install .
+
+.PHONY: run-cli-wheel
+run-cli-wheel: wheel #> Run the program from a (re-)installed wheel
+	@echo ""
+	$(PIPX) install --force --quiet .
+	@$(cmd_name)
+
+.PHONY: uninstall-wheel
+uninstall-wheel:
+	$(PIPX) uninstall $(package_id)
+
+.PHONY: wheel
+wheel: $(wheel_timestamp) #> Build the wheel
+	@:
+
+.PHONY: wheel-contents
+wheel-contents: wheel #> Show what's inside the wheel
+	$(UNZIP) -l $(artifact_wheel)
+
+# Phony target timestamp, to avoid guessing target name of artifact named with source code version
+$(wheel_timestamp): $(sources)
+	$(BUILD) --wheel
+	@touch $@

--- a/src/python/setuptools-src/Pipfile
+++ b/src/python/setuptools-src/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[packages]
+
+[dev-packages]
+build = "*"
+
+[requires]
+python_version = "3.13"
+python_full_version = "3.13.2"
+
+[scripts]
+cli = { call = "setuptoolssrc.cli:main()" }

--- a/src/python/setuptools-src/Pipfile
+++ b/src/python/setuptools-src/Pipfile
@@ -13,4 +13,3 @@ python_version = "3.13"
 python_full_version = "3.13.2"
 
 [scripts]
-cli = { call = "setuptoolssrc.cli:main()" }

--- a/src/python/setuptools-src/Pipfile.lock
+++ b/src/python/setuptools-src/Pipfile.lock
@@ -1,0 +1,47 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "26cb9e138493178f3815c88d0c5bfd92dc8b95db07d0d41c94463ced8cf6537a"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_full_version": "3.13.2",
+            "python_version": "3.13"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "build": {
+            "hashes": [
+                "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5",
+                "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.2.2.post1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pyproject-hooks": {
+            "hashes": [
+                "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8",
+                "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
+        }
+    }
+}

--- a/src/python/setuptools-src/README.md
+++ b/src/python/setuptools-src/README.md
@@ -1,0 +1,88 @@
+# Setuptools with a src directory structure
+
+Learn how to use setuptools with one a standardized, src directory structure.
+
+This tutorial uses [`build`](https://build.pypa.io/en/stable/) to interface with `setuptools`.
+`build` can be installed in a variety of ways:
+
+- install with Homebrew and invoke with `pyproject-build`
+- install in pipenv-managed virtualenv with `pipenv run pip install --upgrade build` and invoke with
+  `pipenv run build ...`.
+
+Source: <https://setuptools.pypa.io/en/latest/userguide/quickstart.html>
+
+## Code structure
+
+This tutorial is using the "src layout", such as in this example:
+
+```shell
+project_root_directory
+├── pyproject.toml  # AND/OR setup.cfg, setup.py
+├── ...
+└── src/
+    └── mypkg/
+        ├── __init__.py
+        ├── ...
+        ├── module.py #contains run_main function
+        ├── subpkg1/
+        │   ├── __init__.py
+        │   ├── ...
+        │   └── module1.py
+```
+
+Specifically:
+
+- `pyproject.toml` et al live in the project's root directory
+- Each package (a directory containing `__init__.py`) is in its own directory in `src/`.
+- Modules are source files within each package, containing functions, classes, etc...
+- Scripts and entrypoints refer to these with "entrypoint syntax": `package.module:function`.  In
+  this example, it would be `dothething = "mypkg.module:run_main"`.
+
+Source: <https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout>
+
+## Create package
+
+```shell
+pipenv run python -m build
+```
+
+or `make`, for short.  Artifacts appear in `dist/`.
+
+## Install package with pipx
+
+The Homebrew-based installation of Python will complain if you try to install packages with `pip`
+and instead point you to other homebrew packages and/or virtualenv.  So use `pipx` for this. It
+looks analogous to `npx` for Node.js.
+
+Install the package with this:
+
+```shell
+pipx install .
+```
+
+or
+
+```shell
+pipx install <path/to/setuptools-src>
+```
+
+## Install editable package with pipx
+
+Install the package using links instead of copying the package, so that editing sources in the
+project gets reflected when you use the package and/or use its scripts in the outside world.
+
+```shell
+pipx install --editable .
+```
+
+## Run local code with python
+
+```shell
+pipenv run python setuptoolssrc/cli.py
+```
+
+## Run local code with pipenv script
+
+```shell
+pipenv run main-call
+```

--- a/src/python/setuptools-src/README.md
+++ b/src/python/setuptools-src/README.md
@@ -78,11 +78,9 @@ pipx install --editable .
 ## Run local code with python
 
 ```shell
-pipenv run python setuptoolssrc/cli.py
+PYTHONPATH=src pipenv run python src/setuptoolssrc/cli.py
 ```
 
 ## Run local code with pipenv script
 
-```shell
-pipenv run main-call
-```
+This doesn't appear to work.

--- a/src/python/setuptools-src/pyproject.toml
+++ b/src/python/setuptools-src/pyproject.toml
@@ -11,6 +11,11 @@ name = "setuptoolssrc"
 [project.scripts]
 marvin = "setuptoolssrc.cli:main"
 
+[tool.setuptools]
+# Support src layout for editable mode
+# https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout
+package-dir = { "" = "src" }
+
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 [tool.setuptools.dynamic]
 version = { attr = "setuptoolssrc._version.__version__" }

--- a/src/python/setuptools-src/pyproject.toml
+++ b/src/python/setuptools-src/pyproject.toml
@@ -11,11 +11,6 @@ name = "setuptoolssrc"
 [project.scripts]
 marvin = "setuptoolssrc.cli:main"
 
-[tool.setuptools]
-# Support src layout for editable mode
-# https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout
-package-dir = { "" = "src" }
-
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 [tool.setuptools.dynamic]
 version = { attr = "setuptoolssrc._version.__version__" }

--- a/src/python/setuptools-src/pyproject.toml
+++ b/src/python/setuptools-src/pyproject.toml
@@ -1,0 +1,16 @@
+# https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools"]
+
+[project]
+dependencies = []
+dynamic = ["version"]
+name = "setuptoolssrc"
+
+[project.scripts]
+marvin = "setuptoolssrc.cli:main"
+
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
+[tool.setuptools.dynamic]
+version = { attr = "setuptoolssrc._version.__version__" }

--- a/src/python/setuptools-src/src/setuptoolssrc/_version.py
+++ b/src/python/setuptools-src/src/setuptoolssrc/_version.py
@@ -1,0 +1,3 @@
+# One canonical place for the version, without loading the regular package in setuptools
+# https://stackoverflow.com/a/7071358/112682
+__version__ = "0.0.1"

--- a/src/python/setuptools-src/src/setuptoolssrc/cli.py
+++ b/src/python/setuptools-src/src/setuptoolssrc/cli.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from setuptoolssrc.greeting import make_greeting
+from setuptoolssrc.marvin import suite_version
+
+def main():
+    print(f"Version: {suite_version()}")
+    print(make_greeting())
+
+if __name__ == '__main__':
+    main()

--- a/src/python/setuptools-src/src/setuptoolssrc/greeting.py
+++ b/src/python/setuptools-src/src/setuptoolssrc/greeting.py
@@ -1,0 +1,2 @@
+def make_greeting():
+    return "Greetings, Earthling"

--- a/src/python/setuptools-src/src/setuptoolssrc/marvin.py
+++ b/src/python/setuptools-src/src/setuptoolssrc/marvin.py
@@ -1,0 +1,4 @@
+from setuptoolssrc import _version
+
+def suite_version():
+    return _version.__version__


### PR DESCRIPTION
# Try src-layout

Try the src-layout for python build.  The directory structure is a little more
separated by concern, but you can't run with a pipenv script or have imports
work the same in an editable installation, anymore.  Editable installs have to
import `src.setuptoolssrc` istead of the `import setuptoolssrc` in the regular
code.  That's when you're in a `python` REPL.
