### PR TITLE
Add --version

### DIFF
--- a/.github/workflows/sode-python.yml
+++ b/.github/workflows/sode-python.yml
@@ -104,4 +104,4 @@ jobs:
       - run: pip install pipenv
       - run: pipenv install --dev
       - run: make install
-      - run: sode
+      - run: sode --version

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "python.createEnvironment.contentButton": "show"
+}

--- a/src/sode/python/.env
+++ b/src/sode/python/.env
@@ -1,0 +1,5 @@
+# Variables that pipenv will add to the virtual environment.
+# https://pipenv.pypa.io/en/latest/shell.html
+
+# Add to–not override–the system path to include project modules
+PYTHONPATH=".:${PYTHONPATH}"

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -225,15 +225,15 @@ run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible
 .PHONY: run-cli-pipenv
 run-cli-pipenv: #> Run the program from a pipenv script
 	@echo ""
-	$(PIPENV) run sode-cli
+	$(PIPENV) run sode-cli --version
 
 .PHONY: run-cli-python
 run-cli-python: #> Run the program from venv-managed python
 	@echo ""
-	PYTHONPATH=. $(PIPENV) run python ./sode/cli.py
+	PYTHONPATH=. $(PIPENV) run python ./sode/cli.py --version
 
 .PHONY: run-cli-wheel
 run-cli-wheel: wheel #> Run the program from a (re-)installed wheel
 	@echo ""
 	$(PIPX) install --force --quiet .
-	@$(cmd_name)
+	@$(cmd_name) --version

--- a/src/sode/python/README.md
+++ b/src/sode/python/README.md
@@ -19,6 +19,35 @@ yet.
 Remember to use `pipenv shell` to set up the python interpreter.  This appears to happen
 automatically with the use of a local `.envrc`.
 
+Pipenv automatically loads the contents of `.env` as environment variables when running anything
+with pipenv.  In this fashion, it adds the project directory to `PYTHONPATH` so that sode can find
+its own sources when running from local sources.
+
+I don't think changes to `PYTHONPATH` will be necessary when running from a pipx-installed package,
+but we'll find out soon enough.
+
+## Run like a developer (e.g. from local sources)
+
+### pipenv script
+
+```shell
+pipenv run sode-cli --version
+```
+
+### python invocation
+
+```shell
+pipenv run python ./sode/cli.py --version
+```
+
+## Run like a user (e.g. from installed package)
+
+```shell
+# from this directory
+pipx install [--force] .
+sode --version
+```
+
 ## Setup
 
 ### Activate virtual environment

--- a/src/sode/python/sode/cli.py
+++ b/src/sode/python/sode/cli.py
@@ -28,7 +28,7 @@ def do_main(argv):
 
     args = parser.parse_args(args=argv[1:])
     if args.version:
-        print(f"Version {sode._version.__version__}")
+        print(f"{sode._version.__version__}")
         return 0
 
     print("Hello world!")

--- a/src/sode/python/sode/cli.py
+++ b/src/sode/python/sode/cli.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 
+import sys
 
-def main():
+
+def main(argv):
     print("Hello world!")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    status = main(sys.argv)
+    sys.exit(status)

--- a/src/sode/python/sode/cli.py
+++ b/src/sode/python/sode/cli.py
@@ -1,13 +1,39 @@
 #!/usr/bin/env python3
 
 import sys
+from argparse import ArgumentParser
+
+import sode._version
 
 
-def main(argv):
+def main():
+    status = do_main(sys.argv)
+    sys.exit(status)
+
+
+def do_main(argv):
+    parser = ArgumentParser(
+        add_help=True,
+        description="BRODE SODE",
+        prog=argv[0],
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        default=False,
+        help="Print version",
+    )
+
+    args = parser.parse_args(args=argv[1:])
+    if args.version:
+        print(f"Version {sode._version.__version__}")
+        return 0
+
     print("Hello world!")
     return 0
 
 
 if __name__ == "__main__":
-    status = main(sys.argv)
-    sys.exit(status)
+    main()


### PR DESCRIPTION
# Add --version

Do the smallest possible thing with `sode`, and that's adding the `--version` option.

Supporting changes:

- Add `.env` so that `pipenv` adds the project directory to `PYTHONPATH`.  This
  allows `cli.py` to find other sources in the same project.  Note that this is
  not necessary when installing as a package.
