### PR TITLE
Use logging over print

### DIFF
--- a/src/sode/python/cspell.config.yaml
+++ b/src/sode/python/cspell.config.yaml
@@ -19,6 +19,7 @@ words:
   - dmypy
   - globalcmd
   - isort
+  - levelname
   - Madoshakalaka
   - mypy
   - MYPYFLAGS

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
 import logging
-import logging.config
 import sys
 from argparse import ArgumentError, ArgumentParser, _SubParsersAction
-from pprint import pprint
 from typing import NoReturn
 
 from sode import version
@@ -33,15 +31,8 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
-    logging.basicConfig(
-        format="""[{name}:{levelname}] {message}""",
-        level=args.log_level,
-        style="{",
-    )
-
-    logger = logging.getLogger(__name__)
-    logger.debug({"args": args})
-
+    args.configure_logging()
+    logging.getLogger(__name__).debug({"args": args})
     return args.run_selected(args, state)
 
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
+import logging
 import sys
 from argparse import ArgumentError, ArgumentParser, _SubParsersAction
-from pprint import pprint
 from typing import NoReturn
 
 from sode import version
@@ -31,7 +31,8 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
-    pprint({"main": {"args": args}}, stream=state.stdout)
+    logger = logging.getLogger(main_fn.__module__)
+    logger.info({"main": {"args": args}})
     return args.run_selected(args, state)
 
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -33,7 +33,7 @@ def main_fn(state: MainState) -> int:
         return 1
 
     logging.basicConfig(
-        format="""{{ "level": {levelname!r}, "name": {name!r}, "msg": {message!r} }}""",
+        format="""[{name}:{levelname}] {message}""",
         # level=logging.DEBUG,
         style="{",
     )

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -33,20 +33,16 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
-    pprint({"args": args})
-    if args.debug:
-        level = logging.DEBUG
-    else:
-        level = logging.WARNING
     logging.basicConfig(
         format="""[{name}:{levelname}] {message}""",
-        level=level,
+        level=args.log_level,
         style="{",
     )
 
     logger = logging.getLogger(__name__)
     logger.error("string message")
-    logger.error({"message": "object message"})
+    logger.warning("warning message")
+    logger.info("info message")
     logger.debug({"args": args})
 
     return args.run_selected(args, state)

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import logging
+import logging.config
 import sys
 from argparse import ArgumentError, ArgumentParser, _SubParsersAction
 from typing import NoReturn
@@ -31,8 +32,16 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
-    logger = logging.getLogger(main_fn.__module__)
-    logger.info({"main": {"args": args}})
+    logging.basicConfig(level=logging.DEBUG)
+
+    # logger = logging.getLogger(main_fn.__module__)
+    root_logger = logging.getLogger(__name__)
+    root_logger.error("error message")
+    root_logger.warning("warning message")
+    root_logger.info("info message")
+    root_logger.debug("debug message")
+    root_logger.debug({"args": args})
+
     return args.run_selected(args, state)
 
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -9,7 +9,7 @@ from sode import version
 from sode.cli.state import MainState
 from sode.fs.cli import add_fs
 from sode.greet.cli import add_greet
-from sode.shared.cli.namespace import ProgramNamespace, add_command_subparsers, add_global_arguments
+from sode.shared.cli.namespace import ProgramNamespace, add_command_parsers, add_global_arguments
 from sode.soundcloud.cli import add_soundcloud
 
 
@@ -52,7 +52,7 @@ def new_main_parser(state: MainState) -> tuple[  # type: ignore[type-arg]
     add_global_arguments(main_parser, state.version)
     return (
         main_parser,
-        add_command_subparsers(main_parser),
+        add_command_parsers(main_parser),
     )
 
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -40,9 +40,6 @@ def main_fn(state: MainState) -> int:
     )
 
     logger = logging.getLogger(__name__)
-    logger.error("string message")
-    logger.warning("warning message")
-    logger.info("info message")
     logger.debug({"args": args})
 
     return args.run_selected(args, state)

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -4,6 +4,7 @@ import logging
 import logging.config
 import sys
 from argparse import ArgumentError, ArgumentParser, _SubParsersAction
+from pprint import pprint
 from typing import NoReturn
 
 from sode import version
@@ -32,6 +33,7 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
+    pprint({"args": args})
     if args.debug:
         level = logging.DEBUG
     else:

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -32,15 +32,16 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(
+        format="""{{ "level": {levelname!r}, "name": {name!r}, "msg": {message!r} }}""",
+        # level=logging.DEBUG,
+        style="{",
+    )
 
-    # logger = logging.getLogger(main_fn.__module__)
-    root_logger = logging.getLogger(__name__)
-    root_logger.error("error message")
-    root_logger.warning("warning message")
-    root_logger.info("info message")
-    root_logger.debug("debug message")
-    root_logger.debug({"args": args})
+    logger = logging.getLogger(__name__)
+    logger.error("string message")
+    logger.error({"message": "object message"})
+    logger.debug({"args": args})
 
     return args.run_selected(args, state)
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -32,9 +32,13 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
+    if args.debug:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
     logging.basicConfig(
         format="""[{name}:{levelname}] {message}""",
-        # level=logging.DEBUG,
+        level=level,
         style="{",
     )
 

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -31,8 +31,10 @@ def main_fn(state: MainState) -> int:
         print(str(error), file=state.stderr)
         return 1
 
+    # Configure logging before accessing logger (getting the order wrong is a world of silent pain).
     args.configure_logging()
     logging.getLogger(__name__).debug({"args": args})
+
     return args.run_selected(args, state)
 
 

--- a/src/sode/python/sode/fs/cli.py
+++ b/src/sode/python/sode/fs/cli.py
@@ -2,6 +2,7 @@ from argparse import _SubParsersAction
 
 from sode.fs.find import add_find
 from sode.fs.shared import FS_COMMAND
+from sode.shared.cli.namespace import add_subcommand_parsers
 
 
 def add_fs(
@@ -14,10 +15,6 @@ def add_fs(
         description="Hack a local filesystem",
         help="hack a local filesystem",
     )
-    fs_subcommands = fs_parser.add_subparsers(
-        dest=FS_COMMAND,
-        metavar="SUBCOMMAND",
-        title="subcommands",
-    )
 
+    fs_subcommands = add_subcommand_parsers(fs_parser, FS_COMMAND)
     add_find(fs_subcommands)

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -60,7 +60,6 @@ def _run_find(args: ProgramNamespace, state: RunState) -> int:
                 "args": args,
                 "command": args.command,
                 FS_COMMAND: getattr(args, FS_COMMAND),
-                "debug": args.debug,
                 "exclude": args.exclude,
                 "glob": args.glob,
                 "path": args.path,

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -11,6 +11,8 @@ from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 from sode.shared.fp.option import Empty, Value
 
+logger = logging.getLogger(__name__)
+
 
 def add_find(
     subcommands: _SubParsersAction,  # type: ignore[type-arg]
@@ -54,7 +56,7 @@ def add_find(
 
 
 def _run_find(args: ProgramNamespace, state: RunState) -> int:
-    logging.getLogger(__name__).debug(
+    logger.debug(
         {
             "fs-find": {
                 "command": args.command,

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Iterable
 
 from sode.fs.shared import FS_COMMAND
-from sode.shared.cli import namespace
+from sode.shared.cli import factory
 from sode.shared.cli.format import DefaultsAndRawTextFormatter
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
@@ -19,14 +19,15 @@ def add_find(
 ) -> None:
     """Add the find sub-command"""
 
-    find_parser = subcommands.add_parser(
+    find_parser = factory.add_command(
+        subcommands,
         "find",
+        command=_run_find,
         description="Find files matching any of the specified criteria",
         epilog="""Example: %(prog)s --glob '**/index.[j,t]s' ~/git/node-sandbox ~/git/react""",
         formatter_class=DefaultsAndRawTextFormatter,
         help="find files lurking in the dark",
     )
-    namespace.set_parser_command(find_parser, _run_find)
 
     find_parser.add_argument(
         "--exclude",

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -1,7 +1,7 @@
+import logging
 import textwrap
 from argparse import _SubParsersAction
 from pathlib import Path
-from pprint import pprint
 from typing import Iterable
 
 from sode.fs.shared import FS_COMMAND
@@ -54,18 +54,16 @@ def add_find(
 
 
 def _run_find(args: ProgramNamespace, state: RunState) -> int:
-    pprint(
+    logging.getLogger(__name__).debug(
         {
             "fs-find": {
-                "args": args,
                 "command": args.command,
                 FS_COMMAND: getattr(args, FS_COMMAND),
                 "exclude": args.exclude,
                 "glob": args.glob,
                 "path": args.path,
             }
-        },
-        stream=state.stdout,
+        }
     )
 
     for search_glob in args.glob:

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -27,7 +27,6 @@ def _greet_run(args: ProgramNamespace, state: RunState) -> int:
             "greet": {
                 "args": args,
                 "command": args.command,
-                "debug": args.debug,
                 "who": args.who,
             }
         }

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -26,7 +26,6 @@ def _greet_run(args: ProgramNamespace, state: RunState) -> int:
     logger.debug(
         {
             "greet": {
-                "args": args,
                 "command": args.command,
                 "who": args.who,
             }

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -22,7 +22,7 @@ def add_greet(
 
 def _greet_run(args: ProgramNamespace, state: RunState) -> int:
     logger = logging.getLogger(_greet_run.__module__)
-    logger.info(
+    logger.debug(
         {
             "greet": {
                 "args": args,

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -1,7 +1,8 @@
+import logging
 from argparse import _SubParsersAction
 from pprint import pprint
 
-from sode.shared.cli import namespace
+from sode.shared.cli.factory import add_unlisted_command
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 
@@ -11,13 +12,7 @@ def add_greet(
 ) -> None:
     """Add a parser for the greet command"""
 
-    # Provide the command, but don't list it in the help
-    greet_parser = commands.add_parser(
-        "greet",
-        description="Start with a greeting",
-    )
-    namespace.set_parser_command(greet_parser, _greet_run)
-
+    greet_parser = add_unlisted_command(commands, "greet", "Start with a greeting", _greet_run)
     greet_parser.add_argument(
         "who",
         default="World",
@@ -27,6 +22,7 @@ def add_greet(
 
 
 def _greet_run(args: ProgramNamespace, state: RunState) -> int:
+    # logging.getLogger(__package__)
     pprint(
         {
             "greet": {

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -5,6 +5,8 @@ from sode.shared.cli.factory import add_unlisted_command
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 
+logger = logging.getLogger(__name__)
+
 
 def add_greet(
     commands: _SubParsersAction,  # type: ignore[type-arg]
@@ -21,7 +23,6 @@ def add_greet(
 
 
 def _greet_run(args: ProgramNamespace, state: RunState) -> int:
-    logger = logging.getLogger(_greet_run.__module__)
     logger.debug(
         {
             "greet": {

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -1,6 +1,5 @@
 import logging
 from argparse import _SubParsersAction
-from pprint import pprint
 
 from sode.shared.cli.factory import add_unlisted_command
 from sode.shared.cli.namespace import ProgramNamespace
@@ -22,8 +21,8 @@ def add_greet(
 
 
 def _greet_run(args: ProgramNamespace, state: RunState) -> int:
-    # logging.getLogger(__package__)
-    pprint(
+    logger = logging.getLogger(_greet_run.__module__)
+    logger.info(
         {
             "greet": {
                 "args": args,
@@ -31,8 +30,7 @@ def _greet_run(args: ProgramNamespace, state: RunState) -> int:
                 "debug": args.debug,
                 "who": args.who,
             }
-        },
-        stream=state.stdout,
+        }
     )
 
     print(f"Hello {args.who}", file=state.stdout)

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import _SubParsersAction
 
-from sode.shared.cli.factory import add_unlisted_command
+from sode.shared.cli import factory
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 
@@ -13,7 +13,13 @@ def add_greet(
 ) -> None:
     """Add a parser for the greet command"""
 
-    greet_parser = add_unlisted_command(commands, "greet", "Start with a greeting", _greet_run)
+    greet_parser = factory.add_unlisted_command(
+        commands,
+        "greet",
+        command=_greet_run,
+        description="Start with a greeting",
+    )
+
     greet_parser.add_argument(
         "who",
         default="World",

--- a/src/sode/python/sode/shared/cli/factory.py
+++ b/src/sode/python/sode/shared/cli/factory.py
@@ -1,14 +1,38 @@
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import ArgumentParser, HelpFormatter, _SubParsersAction
+from typing import Any
 
 from sode.shared.cli import namespace
 from sode.shared.cli.namespace import CliCommand
 
 
+def add_command(
+    commands: _SubParsersAction,  # type: ignore[type-arg]
+    name: str,
+    command: CliCommand,
+    description: str = "",
+    epilog: str = "",
+    formatter_class: Any = HelpFormatter,
+    help: str = "",
+) -> ArgumentParser:
+    """Make an ArgumentParser which will be omitted from help text, but still runs."""
+
+    parser: ArgumentParser = commands.add_parser(
+        name,
+        description=description,
+        epilog=epilog,
+        formatter_class=formatter_class,
+        help=help,
+    )
+
+    namespace.set_parser_command(parser, command)
+    return parser
+
+
 def add_unlisted_command(
     commands: _SubParsersAction,  # type: ignore[type-arg]
     name: str,
-    description: str,
     command: CliCommand,
+    description: str = "",
 ) -> ArgumentParser:
     """Make an ArgumentParser which will be omitted from help text, but still runs."""
 

--- a/src/sode/python/sode/shared/cli/factory.py
+++ b/src/sode/python/sode/shared/cli/factory.py
@@ -1,0 +1,17 @@
+from argparse import ArgumentParser, _SubParsersAction
+
+from sode.shared.cli import namespace
+from sode.shared.cli.namespace import CliCommand
+
+
+def add_unlisted_command(
+    commands: _SubParsersAction,  # type: ignore[type-arg]
+    name: str,
+    description: str,
+    command: CliCommand,
+) -> ArgumentParser:
+    """Make an ArgumentParser which will be omitted from help text, but still runs."""
+
+    parser: ArgumentParser = commands.add_parser(name, description=description)
+    namespace.set_parser_command(parser, command)
+    return parser

--- a/src/sode/python/sode/shared/cli/namespace.py
+++ b/src/sode/python/sode/shared/cli/namespace.py
@@ -1,3 +1,4 @@
+import logging
 from argparse import ArgumentParser, Namespace, _SubParsersAction
 from typing import Callable
 
@@ -29,6 +30,15 @@ def add_command_subparsers(
 
 def add_global_arguments(parser: ArgumentParser, version: str) -> None:
     """Add global options that are used in this namespace."""
+
+    parser.add_argument(
+        "--log-level",
+        choices=list(logging.getLevelNamesMapping().keys()),
+        default=logging.getLevelName(logging.WARNING),
+        help="show log messages at or above { %(choices)s } (default: %(default)s)",
+        metavar="LEVEL",
+        required=False,
+    )
 
     parser.add_argument(
         "--debug",

--- a/src/sode/python/sode/shared/cli/namespace.py
+++ b/src/sode/python/sode/shared/cli/namespace.py
@@ -1,10 +1,21 @@
 import logging
 from argparse import ArgumentParser, Namespace, _SubParsersAction
-from typing import Callable
+from typing import Callable, Literal
 
 from sode.shared.cli.state import RunState
 
 type CliCommand = Callable[["ProgramNamespace", RunState], int]
+
+type LogLevel = Literal[
+    "CRITICAL",
+    "FATAL",
+    "ERROR",
+    "WARN",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+    "NOTSET",
+]
 
 
 class ProgramNamespace(Namespace):
@@ -12,6 +23,7 @@ class ProgramNamespace(Namespace):
 
     command: str
     debug: bool
+    log_level: LogLevel
     run_selected: CliCommand
 
 

--- a/src/sode/python/sode/shared/cli/namespace.py
+++ b/src/sode/python/sode/shared/cli/namespace.py
@@ -34,7 +34,7 @@ class ProgramNamespace(Namespace):
         )
 
 
-def add_command_subparsers(
+def add_command_parsers(
     main_parser: ArgumentParser,
 ) -> _SubParsersAction:  # type: ignore[type-arg]
     """Add an argument subparser group for commands to be added to the returned object"""
@@ -44,6 +44,20 @@ def add_command_subparsers(
         metavar="COMMAND",
         required=True,
         title="commands",
+    )
+
+
+def add_subcommand_parsers(
+    command_parser: ArgumentParser,
+    dest: str,
+) -> _SubParsersAction:  # type: ignore[type-arg]
+    """Add an argument subparser group for sub-commands to be added to the returned object"""
+
+    return command_parser.add_subparsers(
+        dest=dest,
+        metavar="SUBCOMMAND",
+        required=True,
+        title="subcommands",
     )
 
 

--- a/src/sode/python/sode/shared/cli/namespace.py
+++ b/src/sode/python/sode/shared/cli/namespace.py
@@ -22,7 +22,6 @@ class ProgramNamespace(Namespace):
     """Groups together parsed arguments and the indicated CLI command to run with them."""
 
     command: str
-    debug: bool
     log_level: LogLevel
     run_selected: CliCommand
 
@@ -52,11 +51,6 @@ def add_global_arguments(parser: ArgumentParser, version: str) -> None:
         required=False,
     )
 
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="turn on the debug logger",
-    )
     parser.add_argument(
         "--version",
         action="version",

--- a/src/sode/python/sode/shared/cli/namespace.py
+++ b/src/sode/python/sode/shared/cli/namespace.py
@@ -25,6 +25,14 @@ class ProgramNamespace(Namespace):
     log_level: LogLevel
     run_selected: CliCommand
 
+    def configure_logging(self) -> None:
+        """Run basicConfig on logging with the selected log level"""
+        logging.basicConfig(
+            format="""[{name}:{levelname}] {message}""",
+            level=self.log_level,
+            style="{",
+        )
+
 
 def add_command_subparsers(
     main_parser: ArgumentParser,

--- a/src/sode/python/sode/shared/cli/state.py
+++ b/src/sode/python/sode/shared/cli/state.py
@@ -1,4 +1,5 @@
 import typing
+from logging import Logger
 
 
 class RunState:
@@ -14,3 +15,5 @@ class RunState:
     ):
         self.stderr = stderr
         self.stdout = stdout
+
+    # def logger(self, caller: object) -> Logger:

--- a/src/sode/python/sode/shared/fp/either.py
+++ b/src/sode/python/sode/shared/fp/either.py
@@ -34,6 +34,7 @@ class EitherBase[A, B]:
         """Transform Right's inner value with the given function, or return Left unchanged."""
         pass
 
+    # TODO KDK: Revisit these https://stackoverflow.com/questions/1436703/what-is-the-difference-between-str-and-repr/1436756#1436756
     @abstractmethod
     def __repr__(self) -> str:
         pass

--- a/src/sode/python/sode/soundcloud/auth.py
+++ b/src/sode/python/sode/soundcloud/auth.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import _SubParsersAction
 
-from sode.shared.cli import namespace
+from sode.shared.cli import factory
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 from sode.soundcloud.shared import SC_COMMAND
@@ -14,12 +14,13 @@ def add_auth(
 ) -> None:
     """Add the auth sub-command"""
 
-    auth_parser = subcommands.add_parser(
+    auth_parser = factory.add_command(
+        subcommands,
         "auth",
+        command=_run_auth,
         description="Authorize with the SoundCloud API",
         help="authorize with SoundCloud API [start here]",
     )
-    namespace.set_parser_command(auth_parser, _run_auth)
 
     auth_parser.add_argument(
         "--check-token-expiration",

--- a/src/sode/python/sode/soundcloud/auth.py
+++ b/src/sode/python/sode/soundcloud/auth.py
@@ -46,7 +46,6 @@ def _run_auth(args: ProgramNamespace, state: RunState) -> int:
                 "check_token_expiration": args.check_token_expiration,
                 "client_id": args.client_id,
                 "client_secret": args.client_secret,
-                "debug": args.debug,
             }
         },
         stream=state.stdout,

--- a/src/sode/python/sode/soundcloud/auth.py
+++ b/src/sode/python/sode/soundcloud/auth.py
@@ -1,5 +1,5 @@
+import logging
 from argparse import _SubParsersAction
-from pprint import pprint
 
 from sode.shared.cli import namespace
 from sode.shared.cli.namespace import ProgramNamespace
@@ -37,18 +37,16 @@ def add_auth(
 
 
 def _run_auth(args: ProgramNamespace, state: RunState) -> int:
-    pprint(
+    logging.getLogger(__name__).debug(
         {
             "soundcloud-auth": {
-                "args": args,
                 "command": args.command,
                 SC_COMMAND: getattr(args, SC_COMMAND),
                 "check_token_expiration": args.check_token_expiration,
                 "client_id": args.client_id,
                 "client_secret": args.client_secret,
             }
-        },
-        stream=state.stdout,
+        }
     )
 
     return 0

--- a/src/sode/python/sode/soundcloud/auth.py
+++ b/src/sode/python/sode/soundcloud/auth.py
@@ -6,6 +6,8 @@ from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 from sode.soundcloud.shared import SC_COMMAND
 
+logger = logging.getLogger(__name__)
+
 
 def add_auth(
     subcommands: _SubParsersAction,  # type: ignore[type-arg]
@@ -37,7 +39,7 @@ def add_auth(
 
 
 def _run_auth(args: ProgramNamespace, state: RunState) -> int:
-    logging.getLogger(__name__).debug(
+    logger.debug(
         {
             "soundcloud-auth": {
                 "command": args.command,

--- a/src/sode/python/sode/soundcloud/cli.py
+++ b/src/sode/python/sode/soundcloud/cli.py
@@ -1,5 +1,6 @@
 from argparse import _SubParsersAction
 
+from sode.shared.cli.namespace import add_subcommand_parsers
 from sode.soundcloud.auth import add_auth
 from sode.soundcloud.shared import SC_COMMAND
 from sode.soundcloud.track import add_track
@@ -15,11 +16,7 @@ def add_soundcloud(
         description="Hack SoundCloud",
         help="hack SoundCloud",
     )
-    sc_subcommands = sc_parser.add_subparsers(
-        dest=SC_COMMAND,
-        metavar="SUBCOMMAND",
-        title="subcommands",
-    )
 
+    sc_subcommands = add_subcommand_parsers(sc_parser, SC_COMMAND)
     add_auth(sc_subcommands)
     add_track(sc_subcommands)

--- a/src/sode/python/sode/soundcloud/track.py
+++ b/src/sode/python/sode/soundcloud/track.py
@@ -33,7 +33,6 @@ def _run_track(args: ProgramNamespace, state: RunState) -> int:
                 "args": args,
                 "command": args.command,
                 SC_COMMAND: getattr(args, SC_COMMAND),
-                "debug": args.debug,
                 "list": args.list,
             }
         },

--- a/src/sode/python/sode/soundcloud/track.py
+++ b/src/sode/python/sode/soundcloud/track.py
@@ -1,5 +1,5 @@
+import logging
 from argparse import _SubParsersAction
-from pprint import pprint
 
 from sode.shared.cli import namespace
 from sode.shared.cli.namespace import ProgramNamespace
@@ -27,7 +27,7 @@ def add_track(
 
 
 def _run_track(args: ProgramNamespace, state: RunState) -> int:
-    pprint(
+    logging.getLogger(__name__).debug(
         {
             "soundcloud-auth": {
                 "args": args,
@@ -35,8 +35,7 @@ def _run_track(args: ProgramNamespace, state: RunState) -> int:
                 SC_COMMAND: getattr(args, SC_COMMAND),
                 "list": args.list,
             }
-        },
-        stream=state.stdout,
+        }
     )
 
     return 0

--- a/src/sode/python/sode/soundcloud/track.py
+++ b/src/sode/python/sode/soundcloud/track.py
@@ -6,6 +6,8 @@ from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 from sode.soundcloud.shared import SC_COMMAND
 
+logger = logging.getLogger(__name__)
+
 
 def add_track(
     subcommands: _SubParsersAction,  # type: ignore[type-arg]
@@ -27,7 +29,7 @@ def add_track(
 
 
 def _run_track(args: ProgramNamespace, state: RunState) -> int:
-    logging.getLogger(__name__).debug(
+    logger.debug(
         {
             "soundcloud-auth": {
                 "args": args,

--- a/src/sode/python/sode/soundcloud/track.py
+++ b/src/sode/python/sode/soundcloud/track.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import _SubParsersAction
 
-from sode.shared.cli import namespace
+from sode.shared.cli import factory
 from sode.shared.cli.namespace import ProgramNamespace
 from sode.shared.cli.state import RunState
 from sode.soundcloud.shared import SC_COMMAND
@@ -14,12 +14,13 @@ def add_track(
 ) -> None:
     """Add the track sub-command"""
 
-    track_parser = subcommands.add_parser(
+    track_parser = factory.add_command(
+        subcommands,
         "track",
+        command=_run_track,
         description="Work with tracks",
         help="hack tracks",
     )
-    namespace.set_parser_command(track_parser, _run_track)
 
     track_parser.add_argument(
         "--list",


### PR DESCRIPTION
# Use logging over print

Re-factor command-line parsing to use `logging`.  Change `--debug` to
`--log-level`.

Also adds `sode.shared.cli.factory`, for adding (sub-)commands to parsers in a
more repeatable manner.
