### PR TITLE
Add argcomplete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
     - id: mypy
       # typing-related dependencies have to be installed b/c pre-commit runs in its own virtualenv
       additional_dependencies:
+      - "argcomplete==3.6.2"
       - "types-requests>=2.32"
       - "types-requests-oauthlib>=2.0"
       exclude: ^src/python/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
       # typing-related dependencies have to be installed b/c pre-commit runs in its own virtualenv
       additional_dependencies:
       - "argcomplete==3.6.2"
-      - "types-requests>=2.32"
-      - "types-requests-oauthlib>=2.0"
+      - "types-requests==2.32.*"
+      - "types-requests-oauthlib==2.0.*"
       exclude: ^src/python/.*$
       name: mypy-sode
       args:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -18,6 +18,7 @@ ignoreWords: []
 import: []
 version: "0.2"
 words:
+  - argcomplete
   - autoupdate
   - Brode
   - checkmake

--- a/src/sode/python/.env
+++ b/src/sode/python/.env
@@ -1,5 +1,3 @@
 # Variables that pipenv will add to the virtual environment.
 # https://pipenv.pypa.io/en/latest/shell.html
 
-# Add to–not override–the system path to include project modules
-PYTHONPATH=".:${PYTHONPATH}"

--- a/src/sode/python/.envrc
+++ b/src/sode/python/.envrc
@@ -4,3 +4,4 @@ source_up .envrc
 # Activate virtualenv, for use of project-specific python and libraries
 # https://github.com/direnv/direnv/blob/master/man/direnv-stdlib.1.md#layout-pipenv
 layout pipenv
+dotenv .env

--- a/src/sode/python/.envrc
+++ b/src/sode/python/.envrc
@@ -7,3 +7,4 @@ layout pipenv
 
 # Add to–not override–the system path to include project modules
 export PYTHONPATH=".:${PYTHONPATH}"
+eval "$(register-python-argcomplete sode)"

--- a/src/sode/python/.envrc
+++ b/src/sode/python/.envrc
@@ -4,4 +4,6 @@ source_up .envrc
 # Activate virtualenv, for use of project-specific python and libraries
 # https://github.com/direnv/direnv/blob/master/man/direnv-stdlib.1.md#layout-pipenv
 layout pipenv
-dotenv .env
+
+# Add to–not override–the system path to include project modules
+export PYTHONPATH=".:${PYTHONPATH}"

--- a/src/sode/python/.envrc
+++ b/src/sode/python/.envrc
@@ -7,4 +7,3 @@ layout pipenv
 
 # Add to–not override–the system path to include project modules
 export PYTHONPATH=".:${PYTHONPATH}"
-eval "$(register-python-argcomplete sode)"

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -255,11 +255,6 @@ $(wheel_timestamp): $(sources)
 
 #. SODE TARGETS
 
-# TODO KDK: Try to get this to work from Makefile
-.PHONY: install-argcomplete
-install-argcomplete:
-	echo "$(register-python-argcomplete sode)"
-
 .PHONY: run-cli
 run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible ways
 	@:

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -255,6 +255,11 @@ $(wheel_timestamp): $(sources)
 
 #. SODE TARGETS
 
+# TODO KDK: Try to get this to work from Makefile
+.PHONY: install-argcomplete
+install-argcomplete:
+	echo "$(register-python-argcomplete3 sode)"
+
 .PHONY: run-cli
 run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible ways
 	@:

--- a/src/sode/python/Makefile
+++ b/src/sode/python/Makefile
@@ -258,7 +258,7 @@ $(wheel_timestamp): $(sources)
 # TODO KDK: Try to get this to work from Makefile
 .PHONY: install-argcomplete
 install-argcomplete:
-	echo "$(register-python-argcomplete3 sode)"
+	echo "$(register-python-argcomplete sode)"
 
 .PHONY: run-cli
 run-cli: run-cli-pipenv run-cli-python run-cli-wheel #> Run the CLI all possible ways

--- a/src/sode/python/Pipfile
+++ b/src/sode/python/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 sort_pipfile = true
 
 [packages]
+argcomplete = "*"
 requests = "*"
 requests-oauthlib = "*"
 

--- a/src/sode/python/Pipfile.lock
+++ b/src/sode/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b5c394cb2987ad012cba94c8c3895bee6ba455f7309217830f8f9d45fc83cfe"
+            "sha256": "e1e89c32ec51d7b888147d6beabe571d176f37c794559b81b11314ad755069f8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,15 @@
         ]
     },
     "default": {
+        "argcomplete": {
+            "hashes": [
+                "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591",
+                "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.6.2"
+        },
         "certifi": {
             "hashes": [
                 "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",

--- a/src/sode/python/README.md
+++ b/src/sode/python/README.md
@@ -38,7 +38,20 @@ sode
 
 ## Setup
 
-## Use `pipenv`
+### Install argcomplete
+
+I haven't thought of a good way to automate this yet, but do this to get tab completion to work:
+
+```shell
+# some directory that is *not* here; e.g. outside of the virtualenv
+pip install argcomplete
+activate-global-python-argcomplete --user
+```
+
+Then tab completion works for `sode` as an installed wheel and also for `./sode/cli/main.py` or
+`python ./sode/cli/main.py`.
+
+### Use `pipenv`
 
 Remember to use `pipenv shell` to set up the python interpreter.  This appears to happen
 automatically with the use of a local `.envrc`.

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -29,7 +29,7 @@ def main_fn(state: MainState) -> int:
     add_greet(command_parsers)
     add_soundcloud(command_parsers)
 
-    argcomplete.autocomplete(main_parser)
+    argcomplete.autocomplete(main_parser, append_space=False)
     try:
         args = main_parser.parse_args(state.arguments, namespace=ProgramNamespace())
     except ArgumentError as error:

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -3,18 +3,16 @@
 
 import logging
 import sys
-from argparse import ArgumentError, ArgumentParser, _SubParsersAction
+from argparse import ArgumentError, _SubParsersAction
 from typing import NoReturn
 
 import argcomplete
 
 import sode
 from sode import version
+from sode.cli import parser
 from sode.cli.state import MainState
-from sode.fs.cli import add_fs
-from sode.greet.cli import add_greet
-from sode.shared.cli import ProgramNamespace, add_command_parsers, add_global_arguments
-from sode.soundcloud.cli import add_soundcloud
+from sode.shared.cli import ProgramNamespace
 
 
 def main() -> NoReturn:
@@ -24,41 +22,19 @@ def main() -> NoReturn:
 
 
 def main_fn(state: MainState) -> int:
-    (main_parser, command_parsers) = new_main_parser(state)
-    add_fs(command_parsers)
-    add_greet(command_parsers)
-    add_soundcloud(command_parsers)
-
-    argcomplete.autocomplete(main_parser, append_space=False)
+    argv_parser = parser.for_argv(state)
+    argcomplete.autocomplete(argv_parser, append_space=False)
     try:
-        args = main_parser.parse_args(state.arguments, namespace=ProgramNamespace())
+        args = argv_parser.parse_args(state.arguments, namespace=ProgramNamespace())
     except ArgumentError as error:
         print(str(error), file=state.stderr)
         return 1
 
     # Configure logging before accessing logger (getting the order wrong is a world of silent pain).
     args.configure_logging()
+
     logging.getLogger(sode.__name__).debug({"args": args})
-
     return args.run_selected(args, state)
-
-
-def new_main_parser(state: MainState) -> tuple[  # type: ignore[type-arg]
-    ArgumentParser,
-    _SubParsersAction,
-]:
-    main_parser = ArgumentParser(
-        add_help=True,
-        description="BRODE SODE: Hack away at deadly computing scenarios",
-        exit_on_error=False,
-        prog=state.program_name,
-    )
-
-    add_global_arguments(main_parser, state.version)
-    return (
-        main_parser,
-        add_command_parsers(main_parser),
-    )
 
 
 if __name__ == "__main__":

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -3,7 +3,7 @@
 
 import logging
 import sys
-from argparse import ArgumentError, _SubParsersAction
+from argparse import ArgumentError
 from typing import NoReturn
 
 import argcomplete

--- a/src/sode/python/sode/cli/main.py
+++ b/src/sode/python/sode/cli/main.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 
 import logging
 import sys
 from argparse import ArgumentError, ArgumentParser, _SubParsersAction
 from typing import NoReturn
+
+import argcomplete
 
 import sode
 from sode import version
@@ -26,6 +29,7 @@ def main_fn(state: MainState) -> int:
     add_greet(command_parsers)
     add_soundcloud(command_parsers)
 
+    argcomplete.autocomplete(main_parser)
     try:
         args = main_parser.parse_args(state.arguments, namespace=ProgramNamespace())
     except ArgumentError as error:

--- a/src/sode/python/sode/cli/parser.py
+++ b/src/sode/python/sode/cli/parser.py
@@ -1,10 +1,11 @@
 from argparse import ArgumentParser
 
-from sode.cli.state import MainState
 from sode.fs.cli import add_fs
 from sode.greet.cli import add_greet
 from sode.shared.cli import add_command_parsers, add_global_arguments
 from sode.soundcloud.cli import add_soundcloud
+
+from .state import MainState
 
 
 def for_argv(state: MainState) -> ArgumentParser:

--- a/src/sode/python/sode/cli/parser.py
+++ b/src/sode/python/sode/cli/parser.py
@@ -11,7 +11,6 @@ from .state import MainState
 def for_argv(state: MainState) -> ArgumentParser:
     """Create an argument parser-containing sub-parsers for each command-to parse the entire argv"""
 
-    # TODO KDK: Fine-tune argcomplete choices for (sub-)commands
     main_parser = _new_main_parser(state)
     command_parsers = add_command_parsers(main_parser)
     add_fs(command_parsers)

--- a/src/sode/python/sode/cli/parser.py
+++ b/src/sode/python/sode/cli/parser.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+
+from sode.cli.state import MainState
+from sode.fs.cli import add_fs
+from sode.greet.cli import add_greet
+from sode.shared.cli import add_command_parsers, add_global_arguments
+from sode.soundcloud.cli import add_soundcloud
+
+
+def for_argv(state: MainState) -> ArgumentParser:
+    """Create an argument parser-containing sub-parsers for each command-to parse the entire argv"""
+
+    main_parser = _new_main_parser(state)
+    command_parsers = add_command_parsers(main_parser)
+    add_fs(command_parsers)
+    add_greet(command_parsers)
+    add_soundcloud(command_parsers)
+
+    return main_parser
+
+
+def _new_main_parser(state: MainState) -> ArgumentParser:
+    main_parser = ArgumentParser(
+        add_help=True,
+        description="BRODE SODE: Hack away at deadly computing scenarios",
+        exit_on_error=False,
+        prog=state.program_name,
+    )
+
+    add_global_arguments(main_parser, state.version)
+    return main_parser

--- a/src/sode/python/sode/cli/parser.py
+++ b/src/sode/python/sode/cli/parser.py
@@ -11,6 +11,7 @@ from .state import MainState
 def for_argv(state: MainState) -> ArgumentParser:
     """Create an argument parser-containing sub-parsers for each command-to parse the entire argv"""
 
+    # TODO KDK: Fine-tune argcomplete choices for (sub-)commands
     main_parser = _new_main_parser(state)
     command_parsers = add_command_parsers(main_parser)
     add_fs(command_parsers)

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -13,6 +13,14 @@ from sode.shared.fp import Empty, Value
 logger = logging.getLogger(__name__)
 
 
+# TODO KDK: Trying to append = to glob so choices can be []
+# def append_equals_completer(action, prefix, **kwargs) -> str:
+#     if action.dest == "glob":
+#         return prefix + "="
+#     else:
+#         return prefix
+
+
 def add_find(
     subcommands: _SubParsersAction,  # type: ignore[type-arg]
 ) -> None:
@@ -42,6 +50,8 @@ def add_find(
         help="path pattern(s) to match (repeatable)",
         metavar="GLOB",
         nargs=1,
+    ).completer = argcomplete.completers.ChoicesCompleter(  # type: ignore[attr-defined, no-untyped-call]
+        choices=[]
     )
 
     find_parser.add_argument(

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -4,6 +4,8 @@ from argparse import _SubParsersAction
 from pathlib import Path
 from typing import Iterable
 
+import argcomplete
+
 from sode.fs import FS_COMMAND
 from sode.shared.cli import DefaultsAndRawTextFormatter, ProgramNamespace, RunState, cmdfactory
 from sode.shared.fp import Empty, Value
@@ -41,6 +43,7 @@ def add_find(
         metavar="GLOB",
         nargs=1,
     )
+
     find_parser.add_argument(
         "path",
         help=textwrap.dedent(
@@ -50,7 +53,7 @@ def add_find(
         """
         ),
         nargs="+",
-    )
+    ).completer = argcomplete.completers.DirectoriesCompleter()  # type: ignore[attr-defined, no-untyped-call]
 
 
 def _run_find(args: ProgramNamespace, state: RunState) -> int:

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -13,14 +13,6 @@ from sode.shared.fp import Empty, Value
 logger = logging.getLogger(__name__)
 
 
-# TODO KDK: Trying to append = to glob so choices can be []
-# def append_equals_completer(action, prefix, **kwargs) -> str:
-#     if action.dest == "glob":
-#         return prefix + "="
-#     else:
-#         return prefix
-
-
 def add_find(
     subcommands: _SubParsersAction,  # type: ignore[type-arg]
 ) -> None:

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from argparse import _SubParsersAction
+from argparse import Action, ArgumentParser, _SubParsersAction
 from pathlib import Path
 from typing import Iterable
 
@@ -42,20 +42,31 @@ def add_find(
         help="path pattern(s) to match (repeatable)",
         metavar="GLOB",
         nargs=1,
-    ).completer = argcomplete.completers.ChoicesCompleter(  # type: ignore[attr-defined, no-untyped-call]
-        choices=[]
     )
 
-    find_parser.add_argument(
-        "path",
-        help=textwrap.dedent(
-            f"""\
+    completable_argument(
+        argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
+        find_parser.add_argument(
+            "path",
+            help=textwrap.dedent(
+                f"""\
             path(s) in which to search for files
             (precede with -- to avoid ambiguity)
         """
+            ),
+            nargs="+",
         ),
-        nargs="+",
-    ).completer = argcomplete.completers.DirectoriesCompleter()  # type: ignore[attr-defined, no-untyped-call]
+    )
+
+
+def completable_argument(
+    completer: argcomplete.completers.BaseCompleter,
+    action: Action,
+) -> Action:
+    """Decorates an argument-parsing action with a completer"""
+
+    action.completer = completer  # type: ignore[attr-defined]
+    return action
 
 
 def _run_find(args: ProgramNamespace, state: RunState) -> int:

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -1,13 +1,19 @@
 import logging
 import textwrap
-from argparse import Action, ArgumentParser, _SubParsersAction
+from argparse import ArgumentParser, _SubParsersAction
 from pathlib import Path
 from typing import Iterable
 
 import argcomplete
 
 from sode.fs import FS_COMMAND
-from sode.shared.cli import DefaultsAndRawTextFormatter, ProgramNamespace, RunState, cmdfactory
+from sode.shared.cli import (
+    DefaultsAndRawTextFormatter,
+    ProgramNamespace,
+    RunState,
+    argfactory,
+    cmdfactory,
+)
 from sode.shared.fp import Empty, Value
 
 logger = logging.getLogger(__name__)
@@ -44,7 +50,7 @@ def add_find(
         nargs=1,
     )
 
-    completable_argument(
+    argfactory.completable_argument(
         argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
         find_parser.add_argument(
             "path",
@@ -57,16 +63,6 @@ def add_find(
             nargs="+",
         ),
     )
-
-
-def completable_argument(
-    completer: argcomplete.completers.BaseCompleter,
-    action: Action,
-) -> Action:
-    """Decorates an argument-parsing action with a completer"""
-
-    action.completer = completer  # type: ignore[attr-defined]
-    return action
 
 
 def _run_find(args: ProgramNamespace, state: RunState) -> int:

--- a/src/sode/python/sode/fs/find.py
+++ b/src/sode/python/sode/fs/find.py
@@ -1,10 +1,8 @@
 import logging
 import textwrap
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import _SubParsersAction
 from pathlib import Path
 from typing import Iterable
-
-import argcomplete
 
 from sode.fs import FS_COMMAND
 from sode.shared.cli import (
@@ -51,7 +49,7 @@ def add_find(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.DirectoriesCompleter(),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         find_parser.add_argument(
             "path",
             help=textwrap.dedent(

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -1,7 +1,9 @@
 import logging
 from argparse import _SubParsersAction
 
-from sode.shared.cli import ProgramNamespace, RunState, cmdfactory
+import argcomplete
+
+from sode.shared.cli import ProgramNamespace, RunState, argfactory, cmdfactory
 
 logger = logging.getLogger(__name__)
 
@@ -18,11 +20,14 @@ def add_greet(
         description="Start with a greeting",
     )
 
-    greet_parser.add_argument(
-        "who",
-        default="World",
-        help="whom to greet",
-        nargs="?",
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        greet_parser.add_argument(
+            "who",
+            default="World",
+            help="whom to greet",
+            nargs="?",
+        ),
     )
 
 

--- a/src/sode/python/sode/greet/cli.py
+++ b/src/sode/python/sode/greet/cli.py
@@ -1,8 +1,6 @@
 import logging
 from argparse import _SubParsersAction
 
-import argcomplete
-
 from sode.shared.cli import ProgramNamespace, RunState, argfactory, cmdfactory
 
 logger = logging.getLogger(__name__)
@@ -21,7 +19,7 @@ def add_greet(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         greet_parser.add_argument(
             "who",
             default="World",

--- a/src/sode/python/sode/shared/cli/argfactory.py
+++ b/src/sode/python/sode/shared/cli/argfactory.py
@@ -20,12 +20,17 @@ def completable_argument(
     return action
 
 
-DefaultArg = TypedDict("DefaultArg", {"default": str})
-OptionalArg = TypedDict("OptionalArg", {"required": Literal[False]})
-RequiredArg = TypedDict("RequiredArg", {"required": Literal[True]})
+def completion_choices(choices: list[str] = []) -> argcomplete.completers.ChoicesCompleter:
+    """Convenience factory to ignore unavoidable typings warning"""
+
+    return argcomplete.completers.ChoicesCompleter(choices=choices)  # type: ignore[no-untyped-call]
 
 
 ## add_argument decorators
+
+DefaultArg = TypedDict("DefaultArg", {"default": str})
+OptionalArg = TypedDict("OptionalArg", {"required": Literal[False]})
+RequiredArg = TypedDict("RequiredArg", {"required": Literal[True]})
 
 
 def environ_or_default(

--- a/src/sode/python/sode/shared/cli/argfactory.py
+++ b/src/sode/python/sode/shared/cli/argfactory.py
@@ -1,12 +1,31 @@
 import logging
 import os
+from argparse import Action
 from typing import Literal, TypedDict, Union
 
+import argcomplete
+
 logger = logging.getLogger(__name__)
+
+## argcomplete decorators
+
+
+def completable_argument(
+    completer: argcomplete.completers.BaseCompleter,
+    action: Action,
+) -> Action:
+    """Decorates an argument-parsing action with a completer"""
+
+    action.completer = completer  # type: ignore[attr-defined]
+    return action
+
 
 DefaultArg = TypedDict("DefaultArg", {"default": str})
 OptionalArg = TypedDict("OptionalArg", {"required": Literal[False]})
 RequiredArg = TypedDict("RequiredArg", {"required": Literal[True]})
+
+
+## add_argument decorators
 
 
 def environ_or_default(

--- a/src/sode/python/sode/soundcloud/auth/cli.py
+++ b/src/sode/python/sode/soundcloud/auth/cli.py
@@ -29,7 +29,7 @@ def add_auth(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         auth_parser.add_argument(
             "--client-id",
             help="OAuth2 client id with which to request access",

--- a/src/sode/python/sode/soundcloud/auth/cli.py
+++ b/src/sode/python/sode/soundcloud/auth/cli.py
@@ -1,7 +1,9 @@
 import logging
 from argparse import _SubParsersAction
 
-from sode.shared.cli import ProgramNamespace, RunState, add_command
+import argcomplete
+
+from sode.shared.cli import ProgramNamespace, RunState, add_command, argfactory
 from sode.soundcloud import SC_COMMAND
 
 logger = logging.getLogger(__name__)
@@ -25,15 +27,23 @@ def add_auth(
         action="store_true",
         help="check if persisted access token has expired",
     )
-    auth_parser.add_argument(
-        "--client-id",
-        help="OAuth2 client id with which to request access",
-        nargs="?",
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        auth_parser.add_argument(
+            "--client-id",
+            help="OAuth2 client id with which to request access",
+            nargs="?",
+        ),
     )
-    auth_parser.add_argument(
-        "--client-secret",
-        help="OAuth2 client secret with which to request access",
-        nargs="?",
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        auth_parser.add_argument(
+            "--client-secret",
+            help="OAuth2 client secret with which to request access",
+            nargs="?",
+        ),
     )
 
 

--- a/src/sode/python/sode/soundcloud/thing.py
+++ b/src/sode/python/sode/soundcloud/thing.py
@@ -4,10 +4,13 @@ import os
 import textwrap
 from argparse import RawTextHelpFormatter, _SubParsersAction
 
+import argcomplete
+
 from sode.shared.cli import (
     ProgramNamespace,
     RunState,
     add_unlisted_command,
+    argfactory,
     environ_or_default,
     environ_or_optional,
     environ_or_required,
@@ -54,41 +57,61 @@ def add_the_thing(
         ),
         formatter_class=RawTextHelpFormatter,
     )
-    thing_parser.add_argument(
-        "--access-token",
-        **environ_or_optional("SOUNDCLOUD_ACCESS_TOKEN", environ),
-        help=argparse.SUPPRESS,  # discourage exposing secret CLI arguments to other users
-        nargs=1,
-    )
-    thing_parser.add_argument(
-        "--client-id",
-        **environ_or_required("SOUNDCLOUD_CLIENT_ID", environ),
-        help="OAuth2 client_id used to request tokens (default: $SOUNDCLOUD_CLIENT_ID)",
-        nargs=1,
-    )
-    thing_parser.add_argument(
-        "--client-secret",
-        **environ_or_required("SOUNDCLOUD_CLIENT_SECRET", environ),
-        help=argparse.SUPPRESS,  # discourage exposing secret CLI arguments to other users
-        nargs=1,
-    )
-    thing_parser.add_argument(
-        "--token-endpoint",
-        **environ_or_default(
-            "SOUNDCLOUD_TOKEN_URL",
-            "https://secure.soundcloud.com/oauth/token",
-            environ,
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        thing_parser.add_argument(
+            "--access-token",
+            **environ_or_optional("SOUNDCLOUD_ACCESS_TOKEN", environ),
+            help=argparse.SUPPRESS,  # discourage exposing secret CLI arguments to other users
+            nargs=1,
         ),
-        help="URL to SoundCloud OAuth2 token endpoint (default: %(default)s)",
-        metavar="URL",
-        nargs=1,
     )
-    thing_parser.add_argument(
-        "-u",
-        "--user-id",
-        **environ_or_required("SOUNDCLOUD_USER_ID", environ),
-        help="SoundCloud user ID",
-        nargs=1,
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        thing_parser.add_argument(
+            "--client-id",
+            **environ_or_required("SOUNDCLOUD_CLIENT_ID", environ),
+            help="OAuth2 client_id used to request tokens (default: $SOUNDCLOUD_CLIENT_ID)",
+            nargs=1,
+        ),
+    )
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        thing_parser.add_argument(
+            "--client-secret",
+            **environ_or_required("SOUNDCLOUD_CLIENT_SECRET", environ),
+            help=argparse.SUPPRESS,  # discourage exposing secret CLI arguments to other users
+            nargs=1,
+        ),
+    )
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        thing_parser.add_argument(
+            "--token-endpoint",
+            **environ_or_default(
+                "SOUNDCLOUD_TOKEN_URL",
+                "https://secure.soundcloud.com/oauth/token",
+                environ,
+            ),
+            help="URL to SoundCloud OAuth2 token endpoint (default: %(default)s)",
+            metavar="URL",
+            nargs=1,
+        ),
+    )
+
+    argfactory.completable_argument(
+        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        thing_parser.add_argument(
+            "-u",
+            "--user-id",
+            **environ_or_required("SOUNDCLOUD_USER_ID", environ),
+            help="SoundCloud user ID",
+            nargs=1,
+        ),
     )
 
 

--- a/src/sode/python/sode/soundcloud/thing.py
+++ b/src/sode/python/sode/soundcloud/thing.py
@@ -59,7 +59,7 @@ def add_the_thing(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         thing_parser.add_argument(
             "--access-token",
             **environ_or_optional("SOUNDCLOUD_ACCESS_TOKEN", environ),
@@ -69,7 +69,7 @@ def add_the_thing(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         thing_parser.add_argument(
             "--client-id",
             **environ_or_required("SOUNDCLOUD_CLIENT_ID", environ),
@@ -79,7 +79,7 @@ def add_the_thing(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         thing_parser.add_argument(
             "--client-secret",
             **environ_or_required("SOUNDCLOUD_CLIENT_SECRET", environ),
@@ -89,7 +89,7 @@ def add_the_thing(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         thing_parser.add_argument(
             "--token-endpoint",
             **environ_or_default(
@@ -104,7 +104,7 @@ def add_the_thing(
     )
 
     argfactory.completable_argument(
-        argcomplete.completers.ChoicesCompleter(choices=[]),  # type: ignore[no-untyped-call]
+        argfactory.completion_choices(),
         thing_parser.add_argument(
             "-u",
             "--user-id",


### PR DESCRIPTION
# Add argcomplete

Add tab-completion to `sode`, as long as you install the (global) hook with `register-python-argcomplete`.

Also includes:

- Move `.env` settings to `.envrc`, so `PYTHONPATH` is always up to date.
- Extract parser creation to its own file.

Future work

- Figure out how to register python completions as part of `make install`.
  This requires further thought, since the python used to run `arcomplete` may
  not be the same as the python used to run `sode`.  Also, getting `Makefile`
  to `eval` anything in a shell is unclear and not the safest practice.  I'd
  rather create a file (containing the `eval` that users can review and choose
  to source themselves, if desired.
